### PR TITLE
Disabled audio for merge into master

### DIFF
--- a/Sail/src/Sail/Application.cpp
+++ b/Sail/src/Sail/Application.cpp
@@ -138,7 +138,7 @@ int Application::startGameLoop() {
 			Input::GetInstance()->beginFrame();
 
 			//UPDATES ALL CURRENTLY-WORKING AUDIO FUNCTIONALITY (TL;DR - Press '9' and '0')
-			Application::getAudioManager()->updateAudio();
+			//Application::getAudioManager()->updateAudio();
 
 			// Quit on alt-f4
 			if (Input::IsKeyPressed(SAIL_KEY_MENU) && Input::IsKeyPressed(SAIL_KEY_F4))


### PR DESCRIPTION
Temporarily disabled audio before sprint merge with master.
Spamming the '2' key with audio enabled freezes the application.