### PR TITLE
Added support for vertex buffer updates in raytracing

### DIFF
--- a/Sail/src/API/DX12/DX12IndexBuffer.h
+++ b/Sail/src/API/DX12/DX12IndexBuffer.h
@@ -11,7 +11,8 @@ public:
 	ID3D12Resource1* getBuffer() const;
 
 private:
-	wComPtr<ID3D12Resource1> m_indexBuffer;
+	DX12API* m_context;
+	std::vector<wComPtr<ID3D12Resource1>> m_indexBuffers;
 
 };
 

--- a/Sail/src/API/DX12/DX12VertexBuffer.cpp
+++ b/Sail/src/API/DX12/DX12VertexBuffer.cpp
@@ -10,20 +10,28 @@ VertexBuffer* VertexBuffer::Create(const InputLayout& inputLayout, Mesh::Data& m
 // TODO: Take in usage (Static or Dynamic) and create a default heap for static only
 // TODO: updateData and/or setData
 DX12VertexBuffer::DX12VertexBuffer(const InputLayout& inputLayout, Mesh::Data& modelData)
-	: VertexBuffer(inputLayout, modelData) {
-	DX12API* context = Application::getInstance()->getAPI<DX12API>();
+	: VertexBuffer(inputLayout, modelData)
+{
+	m_context = Application::getInstance()->getAPI<DX12API>();
 	void* vertices = getVertexData(modelData);
 
-	m_vertexBuffer.Attach(DX12Utils::CreateBuffer(context->getDevice(), getVertexDataSize(), D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_GENERIC_READ, DX12Utils::sUploadHeapProperties));
-	m_vertexBuffer->SetName(L"Vertex buffer");
+	auto numSwapBuffers = m_context->getNumSwapBuffers();
 
-	// Place verticies in the buffer
-	void* pData;
-	D3D12_RANGE readRange{ 0, 0 };
-	ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, &pData));
-	memcpy(pData, vertices, getVertexDataSize());
-	m_vertexBuffer->Unmap(0, nullptr);
+	m_hasBeenUpdated.resize(numSwapBuffers, false);
+	m_vertexBuffers.resize(numSwapBuffers);
 
+	for (unsigned int i = 0; i < numSwapBuffers; i++) {
+		m_vertexBuffers[i].Attach(DX12Utils::CreateBuffer(m_context->getDevice(), getVertexDataSize(), D3D12_RESOURCE_FLAG_NONE, D3D12_RESOURCE_STATE_GENERIC_READ, DX12Utils::sUploadHeapProperties));
+		m_vertexBuffers[i]->SetName(L"Vertex buffer");
+
+		// Place verticies in the buffer
+		void* pData;
+		D3D12_RANGE readRange{ 0, 0 };
+		ThrowIfFailed(m_vertexBuffers[i]->Map(0, &readRange, &pData));
+		memcpy(pData, vertices, getVertexDataSize());
+		m_vertexBuffers[i]->Unmap(0, nullptr);
+
+	}
 	// Delete vertices from cpu memory
 	free(vertices);
 }
@@ -33,10 +41,11 @@ DX12VertexBuffer::~DX12VertexBuffer() {
 }
 
 void DX12VertexBuffer::bind(void* cmdList) const {
+	auto frameIndex = m_context->getFrameIndex();
 	auto* dxCmdList = static_cast<ID3D12GraphicsCommandList4*>(cmdList);
 
 	D3D12_VERTEX_BUFFER_VIEW vbView = {};
-	vbView.BufferLocation = m_vertexBuffer->GetGPUVirtualAddress();
+	vbView.BufferLocation = m_vertexBuffers[frameIndex]->GetGPUVirtualAddress();
 	vbView.SizeInBytes = static_cast<UINT>(getVertexDataSize());
 	vbView.StrideInBytes = static_cast<UINT>(getVertexDataStride());
 	// Later update to just put in a buffer on the renderer to set multiple vertex buffers at once
@@ -44,19 +53,32 @@ void DX12VertexBuffer::bind(void* cmdList) const {
 }
 
 ID3D12Resource1* DX12VertexBuffer::getBuffer() const {
-	return m_vertexBuffer.Get();
+	auto frameIndex = m_context->getFrameIndex();
+	return m_vertexBuffers[frameIndex].Get();
 }
 
 void DX12VertexBuffer::update(Mesh::Data& data) {
-
+	auto frameIndex = m_context->getFrameIndex();
 	void* vertices = getVertexData(data);
 	// Place verticies in the buffer
 	void* pData;
 	D3D12_RANGE readRange{ 0, 0 };
-	ThrowIfFailed(m_vertexBuffer->Map(0, &readRange, &pData));
+	ThrowIfFailed(m_vertexBuffers[frameIndex]->Map(0, &readRange, &pData));
 	memcpy(pData, vertices, getVertexDataSize());
-	m_vertexBuffer->Unmap(0, nullptr);
-
-
+	m_vertexBuffers[frameIndex]->Unmap(0, nullptr);
 	free(vertices);
+
+	//for (unsigned int i = 0; i < m_context->getNumSwapBuffers(); i++) {
+		m_hasBeenUpdated[frameIndex] = true;
+	//}
+}
+
+bool DX12VertexBuffer::hasBeenUpdated() const {
+	auto frameIndex = m_context->getFrameIndex();
+	return m_hasBeenUpdated[frameIndex];
+}
+
+void DX12VertexBuffer::resetHasBeenUpdated() { 
+	auto frameIndex = m_context->getFrameIndex();
+	m_hasBeenUpdated[frameIndex] = false;
 }

--- a/Sail/src/API/DX12/DX12VertexBuffer.h
+++ b/Sail/src/API/DX12/DX12VertexBuffer.h
@@ -10,9 +10,12 @@ public:
 	virtual void bind(void* cmdList) const override;
 	ID3D12Resource1* getBuffer() const;
 	void update(Mesh::Data& data);
+	bool hasBeenUpdated() const;
+	void resetHasBeenUpdated();
 
 private:
-	wComPtr<ID3D12Resource1> m_vertexBuffer;
-
+	DX12API* m_context;
+	std::vector<wComPtr<ID3D12Resource1>> m_vertexBuffers;
+	std::vector<bool> m_hasBeenUpdated;
 };
 

--- a/Sail/src/API/DX12/dxr/DXRBase.h
+++ b/Sail/src/API/DX12/dxr/DXRBase.h
@@ -33,6 +33,7 @@ private:
 		wComPtr<ID3D12Resource1> scratch = nullptr;
 		wComPtr<ID3D12Resource1> result = nullptr;
 		wComPtr<ID3D12Resource1> instanceDesc = nullptr;    // Used only for top-level AS
+		bool allowUpdate = false;
 		void release() {
 			if (scratch) {
 				scratch->Release();

--- a/Sail/src/API/DX12/renderer/DX12RaytracingRenderer.h
+++ b/Sail/src/API/DX12/renderer/DX12RaytracingRenderer.h
@@ -15,7 +15,7 @@ public:
 
 	virtual bool onEvent(Event& event) override;
 
-	virtual void submit(Mesh* mesh, const glm::mat4& modelMatrix) override;
+	virtual void submit(Mesh* mesh, const glm::mat4& modelMatrix, RenderFlag flags) override;
 
 private:
 	bool onResize(WindowResizeEvent& event);

--- a/Sail/src/Sail/api/Renderer.cpp
+++ b/Sail/src/Sail/api/Renderer.cpp
@@ -7,16 +7,17 @@ void Renderer::begin(Camera* camera) {
 	commandQueue.clear();
 }
 
-void Renderer::submit(Model* model, const glm::mat4& modelMatrix) {
+void Renderer::submit(Model* model, const glm::mat4& modelMatrix, RenderFlag flags) {
 	for (unsigned int i = 0; i < model->getNumberOfMeshes(); i++) {
-		submit(model->getMesh(i), modelMatrix);
+		submit(model->getMesh(i), modelMatrix, flags);
 	}
 }
 
-void Renderer::submit(Mesh* mesh, const glm::mat4& modelMatrix) {
+void Renderer::submit(Mesh* mesh, const glm::mat4& modelMatrix, RenderFlag flags) {
 	RenderCommand cmd;
 	cmd.mesh = mesh;
 	cmd.transform = glm::transpose(modelMatrix);
+	cmd.flags = flags;
 	commandQueue.push_back(cmd);
 }
 

--- a/Sail/src/Sail/api/Renderer.h
+++ b/Sail/src/Sail/api/Renderer.h
@@ -23,7 +23,7 @@ public:
 		MESH_STATIC = 1 << 1,		// Vertices will never change
 		MESH_TRANSPARENT = 1 << 2,	// Should be rendered see-through
 		MESH_HERO = 1 << 3			// Mesh takes up a relatively large area of the screen 
-	};
+	};	
 	struct RenderCommand {
 		Mesh* mesh;
 		glm::mat4 transform; // TODO: find out why having a const ptr here doesnt work
@@ -35,8 +35,8 @@ public:
 	virtual ~Renderer() {}
 
 	virtual void begin(Camera* camera);
-	void submit(Model* model, const glm::mat4& modelMatrix);
-	virtual void submit(Mesh* mesh, const glm::mat4& modelMatrix);
+	void submit(Model* model, const glm::mat4& modelMatrix, RenderFlag flags);
+	virtual void submit(Mesh* mesh, const glm::mat4& modelMatrix, RenderFlag flags);
 	virtual void setLightSetup(LightSetup* lightSetup);
 	virtual void end();
 	virtual void present(PostProcessPipeline* postProcessPipeline = nullptr, RenderableTexture* output = nullptr) = 0;
@@ -48,3 +48,11 @@ protected:
 	LightSetup* lightSetup;
 
 };
+
+// Operators to use RenderFlags enum as bit flags
+inline enum Renderer::RenderFlag operator|(const enum Renderer::RenderFlag a, const enum Renderer::RenderFlag b) {
+	return static_cast<enum Renderer::RenderFlag>(static_cast<int>(a) | static_cast<int>(b));
+}
+inline enum Renderer::RenderFlag operator|=(const enum Renderer::RenderFlag a, const enum Renderer::RenderFlag b) {
+	return static_cast<enum Renderer::RenderFlag>(static_cast<int>(a) | static_cast<int>(b));
+}

--- a/Sail/src/Sail/graphics/Scene.cpp
+++ b/Sail/src/Sail/graphics/Scene.cpp
@@ -134,7 +134,7 @@ void Scene::draw(Camera& camera, const float alpha) {
 		StaticMatrixComponent* matrix = entity->getComponent<StaticMatrixComponent>();
 
 		if (model && matrix) {
-			(*m_currentRenderer)->submit(model->getModel(), matrix->getMatrix());
+			(*m_currentRenderer)->submit(model->getModel(), matrix->getMatrix(), (model->getModel()->isAnimated()) ? Renderer::MESH_DYNAMIC : Renderer::MESH_STATIC);
 		}
 
 		if (m_showBoundingBoxes) {
@@ -142,16 +142,18 @@ void Scene::draw(Camera& camera, const float alpha) {
 			if (boundingBox) {
 				Model* wireframeModel = boundingBox->getWireframeModel();
 				if (wireframeModel) {
-					(*m_currentRenderer)->submit(wireframeModel, boundingBox->getTransform()->getMatrix());
+					(*m_currentRenderer)->submit(wireframeModel, boundingBox->getTransform()->getMatrix(), Renderer::MESH_STATIC);
 				}
 			}
 		}
 	}
 
-	TransformComponent* transform = m_playerCandle->getComponent<TransformComponent>();
-	ModelComponent* model = m_playerCandle->getComponent<ModelComponent>();
-	if (transform && model) {
-		(*m_currentRenderer)->submit(model->getModel(), transform->getMatrix());
+	if (m_playerCandle) {
+		TransformComponent* transform = m_playerCandle->getComponent<TransformComponent>();
+		ModelComponent* model = m_playerCandle->getComponent<ModelComponent>();
+		if (transform && model) {
+			(*m_currentRenderer)->submit(model->getModel(), transform->getMatrix(), (model->getModel()->isAnimated()) ? Renderer::MESH_DYNAMIC : Renderer::MESH_STATIC);
+		}
 	}
 
 	// Render dynamic objects (objects that might move or be added/removed)
@@ -159,7 +161,7 @@ void Scene::draw(Camera& camera, const float alpha) {
 	const UINT ind = Scene::GetRenderIndex();
 	m_perFrameLocks[ind].lock();
 	for (PerUpdateRenderObject& obj : m_dynamicRenderObjects[ind]) {
-		(*m_currentRenderer)->submit(obj.getModel(), obj.getMatrix(alpha));
+		(*m_currentRenderer)->submit(obj.getModel(), obj.getMatrix(alpha), (obj.getModel()->isAnimated()) ? Renderer::MESH_DYNAMIC : Renderer::MESH_STATIC);
 	}
 	m_perFrameLocks[ind].unlock();
 

--- a/Sail/src/Sail/graphics/geometry/Model.cpp
+++ b/Sail/src/Sail/graphics/geometry/Model.cpp
@@ -1,50 +1,16 @@
 #include "pch.h"
 #include "Model.h"
 
-//#include "../shader/basic/SimpleColorShader.h"
-#include "Material.h"
-
-Model::Model(Mesh::Data& buildData, Shader* shader) {
-
+Model::Model(Mesh::Data& buildData, Shader* shader) 
+	: m_isAnimated(false)
+{
 	m_meshes.push_back(std::unique_ptr<Mesh>(Mesh::Create(buildData, shader)));
-
-	// TODO: reuse materials (?)
-	//m_material = std::make_shared<Material>(shaderSet);
 }
 
-Model::Model() {
+Model::Model() 
+	: m_isAnimated(false) 
+{ }
 
-}
-
-//Model::Model(const std::string& path, ShaderSet* shaderSet) {
-//	// TODO: reuse mesh if it has already been loaded
-//	// TODO: load mesh from FBX model specified by path
-//	//m_mesh = std::make_shared<Mesh>(buildData, shaderSet);
-//
-//	// TODO: reuse materials (?)
-//	m_material = std::make_shared<Material>(shaderSet);
-//}
-
-//Model::Model(std::vector<Mesh::Data>& data, ShaderSet* shaderSet) {
-//
-//	for (auto& meshData : data) {
-//		m_meshes.push_back(std::make_shared<Mesh>(meshData, shaderSet));
-//	}
-//
-//	//m_material = std::make_shared<Material>(shaderSet);
-//
-//}
-
-//Model::Model(ShaderSet* shaderSet)
-//	: m_aabb(glm::vec3(0.f), glm::vec3(.2f, .2f, .2f))
-//	, m_vertexBuffer(nullptr)
-//	, m_indexBuffer(nullptr)
-//	, m_shader(shaderSet)
-//{
-//	m_material = SAIL_NEW Material();
-//	m_transform = SAIL_NEW Transform();
-//	m_transformChanged = false;
-//}
 Model::~Model() {
 }
 
@@ -53,26 +19,10 @@ Mesh* Model::addMesh(std::unique_ptr<Mesh> mesh) {
 	return m_meshes.back().get();
 }
 
-//void Model::setBuildData(Data& buildData) {
-//	m_data = buildData;
-//}
-//const Model::Data& Model::getBuildData() const {
-//	return m_data;
-//}
-
-//void Model::buildBufferForShader(ShaderSet* shader) {
-//
-//	shader->createBufferFromModelData(&m_vertexBuffer, &m_indexBuffer, &m_instanceBuffer, &m_data);
-//	calculateAABB();
-//
-//}
-
 void Model::draw(const Renderer& renderer) {
-
 	//m_material->bind();
 	for (auto& mesh : m_meshes)
 		mesh->draw(renderer);
-
 }
 
 Mesh* Model::getMesh(unsigned int index) {
@@ -84,42 +34,10 @@ UINT Model::getNumberOfMeshes() const {
 	return static_cast<UINT>(m_meshes.size());
 }
 
-//ShaderSet* Model::getShader() const {
-//	//return m_material->getShader();
-//	return nullptr;
-//}
-//
-//Material* Model::getMaterial() {
-//	//return m_material.get();
-//	return nullptr;
-//}
+void Model::setIsAnimated(bool animated) {
+	m_isAnimated = animated;
+}
 
-//const AABB& Model::getAABB() const {
-//	return m_aabb;
-//}
-//void Model::updateAABB() {
-//	m_aabb.updateTransform(m_transform->getMatrix());
-//}
-//
-//void Model::calculateAABB() {
-//
-//	glm::vec3 minCorner(FLT_MAX, FLT_MAX, FLT_MAX );
-//	glm::vec3 maxCorner(-FLT_MIN, -FLT_MIN, -FLT_MIN);
-//
-//	for (UINT i = 0; i < m_data.numVertices; i++) {
-//		glm::vec3& p = m_data.positions[i];
-//
-//		if (p.x < minCorner.x) minCorner.x = p.x;
-//		if (p.y < minCorner.y) minCorner.y = p.y;
-//		if (p.z < minCorner.z) minCorner.z = p.z;
-//
-//		if (p.x > maxCorner.x) maxCorner.x = p.x;
-//		if (p.y > maxCorner.y) maxCorner.y = p.y;
-//		if (p.z > maxCorner.z) maxCorner.z = p.z;
-//
-//	}
-//
-//	m_aabb.setMinPos(minCorner);
-//	m_aabb.setMaxPos(maxCorner);
-//
-//}
+bool Model::isAnimated() const {
+	return m_isAnimated;
+}

--- a/Sail/src/Sail/graphics/geometry/Model.h
+++ b/Sail/src/Sail/graphics/geometry/Model.h
@@ -15,35 +15,23 @@ public:
 	typedef std::unique_ptr<Model> Ptr;
 
 public: 
-	//Model(std::vector<Mesh::Data>& data, ShaderSet* shaderSet);
 	Model();
 	Model(Mesh::Data& data, Shader* shader);
-	//Model(const std::string& path, ShaderSet* shaderSet);
 	~Model();
 
 	Mesh* addMesh(std::unique_ptr<Mesh> mesh);
-
-	//void setBuildData(Data& buildData);
-	//void buildBufferForShader(ShaderSet* shader);
 
 	// Draws the model using its material
 	void draw(const Renderer& renderer);
 
 	Mesh* getMesh(unsigned int index);
 	UINT getNumberOfMeshes() const;
-	/*ShaderSet* getShader() const;
-	Material* getMaterial();*/
-	//const AABB& getAABB() const;
-	//void updateAABB();
 
-private:
-	//void calculateAABB();
+	void setIsAnimated(bool animated);
+	bool isAnimated() const;
 
 private:
 	std::vector<Mesh::Ptr> m_meshes;
-
-	//Material::SPtr m_material;
-
-	//AABB m_aabb;
+	bool m_isAnimated;
 
 };

--- a/premake5.lua
+++ b/premake5.lua
@@ -68,6 +68,8 @@ project "SPLASH"
 		"Physics"
 	}
 
+	flags { "MultiProcessorCompile" }
+
 	filter "system:windows"
 		systemversion "latest"
 
@@ -147,6 +149,8 @@ project "Sail"
 		"MemoryManager",
 		"assimp-vc140-mt"
 	}
+
+	flags { "MultiProcessorCompile" }
 
 	defines {
 		"SAIL_PLATFORM=\"%{cfg.platform}\""
@@ -229,6 +233,9 @@ project "Physics"
 		"ImGui",
 		"assimp-vc140-mt"
 	}
+
+	flags { "MultiProcessorCompile" }
+
 	filter { "action:vs2017 or vs2019", "platforms:*64" }
 		libdirs {
 			"libraries/FBX_SDK/lib/vs2017/x64/%{cfg.buildcfg}",


### PR DESCRIPTION
Animations are currently very choppy when run in release. This is because I added one VertexBuffer/IndexBuffer per back buffer, and the animation update does not run every frame. Should be fixed ASAP, i.e. when systems have the ability to run every frame.