### PR TITLE
Game statistics is rendered in EndGameState.

### DIFF
--- a/SPLASH/src/game/states/EndGameState.cpp
+++ b/SPLASH/src/game/states/EndGameState.cpp
@@ -15,10 +15,6 @@ EndGameState::~EndGameState() {
 }
 
 bool EndGameState::processInput(float dt) {
-	if (Input::WasMouseButtonJustPressed(KeyBinds::disableCursor)) {
-		Input::HideCursor(!Input::IsCursorHidden());
-	}
-
 	return true;
 }
 

--- a/SPLASH/src/game/states/EndGameState.cpp
+++ b/SPLASH/src/game/states/EndGameState.cpp
@@ -3,7 +3,7 @@
 #include "Sail/Application.h"
 #include "Sail/entities/systems/render/RenderSystem.h"
 #include "Sail/KeyBinds.h"
-
+#include "Sail/utils/GameDataTracker.h"
 
 #include "../libraries/imgui/imgui.h"
 
@@ -31,6 +31,7 @@ bool EndGameState::render(float dt, float alpha) {
 
 	// Call the empty draw function to just clear the screen until we have actual graphics.
 	ECS::Instance()->getSystem<RenderSystem>()->draw();
+
 	return true;
 }
 
@@ -52,6 +53,7 @@ bool EndGameState::renderImgui(float dt) {
 	}
 	ImGui::End();
 
+	GameDataTracker::getInstance().renderImgui();
 
 	return true;
 }

--- a/SPLASH/src/game/states/GameState.cpp
+++ b/SPLASH/src/game/states/GameState.cpp
@@ -802,6 +802,11 @@ bool GameState::renderImGuiLightDebug(float dt) {
 
 void GameState::shutDownGameState() {
 
+	// Show mouse cursor if hidden
+	if (Input::IsCursorHidden()) {
+		Input::HideCursor(!Input::IsCursorHidden());
+	}
+
 	// Reset network
 	NWrapperSingleton::getInstance().resetNetwork();
 

--- a/SPLASH/src/game/states/GameState.cpp
+++ b/SPLASH/src/game/states/GameState.cpp
@@ -535,7 +535,6 @@ bool GameState::processInput(float dt) {
 	return true;
 }
 
-
 bool GameState::onEvent(Event& event) {
 	EventHandler::dispatch<WindowResizeEvent>(event, SAIL_BIND_EVENT(&GameState::onResize));
 	EventHandler::dispatch<PlayerCandleHitEvent>(event, SAIL_BIND_EVENT(&GameState::onPlayerCandleHit));
@@ -856,7 +855,6 @@ void GameState::updatePerTickComponentSystems(float dt) {
 		shutDownGameState();
 	}
 }
-
 
 void GameState::updatePerFrameComponentSystems(float dt, float alpha) {
 	// Updates the camera


### PR DESCRIPTION
Fixed crash when GameDataTracker::renderImgui() was called in the wrong place.
