### PR TITLE
U385/t386 fix aabb with plane

### DIFF
--- a/Physics/Intersection.h
+++ b/Physics/Intersection.h
@@ -9,8 +9,8 @@ struct Frustum;
 class Intersection {
 public:
 	static bool AabbWithAabb(const BoundingBox& aabb1, const BoundingBox& aabb2);
-	static bool AabbWithTriangle(const BoundingBox& aabb, const glm::vec3& v1, const glm::vec3& v2, const glm::vec3& v3);
-	static bool AabbWithPlane(const BoundingBox& aabb, const glm::vec3& normal, const float& distance);
+	static bool AabbWithTriangle(BoundingBox& aabb, const glm::vec3& v1, const glm::vec3& v2, const glm::vec3& v3);
+	static bool AabbWithPlane(BoundingBox& aabb, const glm::vec3& normal, const float distance);
 	static bool AabbWithSphere(BoundingBox& aabb, const Sphere& sphere);
 	static bool AabbWithVerticalCylinder(BoundingBox& aabb, const VerticalCylinder& cyl);
 
@@ -18,13 +18,15 @@ public:
 	static bool TriangleWithSphere(const glm::vec3 tri[3], const Sphere& sphere);
 	static bool TriangleWithVerticalCylinder(const glm::vec3 tri[3], const VerticalCylinder& cyl);
 
+	static bool SphereWithPlane(const Sphere& sphere, const glm::vec3& normal, const float distance);
+
 	static bool PointWithVerticalCylinder(const glm::vec3 p, const VerticalCylinder& cyl);
 
 	static bool LineSegmentWithVerticalCylinder(const glm::vec3& start, const glm::vec3& end, const VerticalCylinder& cyl);
 
 	static float RayWithAabb(const glm::vec3& rayStart, const glm::vec3& rayVec, const BoundingBox& aabb);
 	static float RayWithTriangle(const glm::vec3& rayStart, const glm::vec3& rayDir, const glm::vec3& v1, const glm::vec3& v2, const glm::vec3& v3);
-	static float RayWithPlane(const glm::vec3& rayStart, const glm::vec3& rayDir, const glm::vec3& normal, const float& distance);
+	static float RayWithPlane(const glm::vec3& rayStart, const glm::vec3& rayDir, const glm::vec3& normal, const float distance);
 	static float RayWithPaddedAabb(const glm::vec3& rayStart, const glm::vec3& rayVec, const BoundingBox& aabb, float padding);
 	static float RayWithPaddedTriangle(const glm::vec3& rayStart, const glm::vec3& rayDir, const glm::vec3& v1, const glm::vec3& v2, const glm::vec3& v3, float padding);
 


### PR DESCRIPTION
Added SphereWithPlane() intersection test.
Now SphereWithPlane() is used instead of AabbWithPlane() as early exit in AabbWithTriangle()