### PR TITLE
U414/t507 performance info per tick

### DIFF
--- a/SPLASH/src/game/states/GameState.cpp
+++ b/SPLASH/src/game/states/GameState.cpp
@@ -627,6 +627,9 @@ void GameState::updatePerTickComponentSystems(float dt) {
 	m_runningSystemJobs.clear();
 	m_runningSystems.clear();
 
+	// Update keyboard input
+	m_componentSystems.gameInputSystem->fixedUpdate();
+
 	m_componentSystems.prepareUpdateSystem->update(); // HAS TO BE RUN BEFORE OTHER SYSTEMS WHICH USE TRANSFORM
 	
 	// Update entities with info from the network and from ourself
@@ -674,7 +677,7 @@ void GameState::updatePerFrameComponentSystems(float dt, float alpha) {
 	NWrapperSingleton* ptr = &NWrapperSingleton::getInstance();
 	NWrapperSingleton::getInstance().getNetworkWrapper()->checkForPackages();
 
-	// Updates the camera
+	// Updates mouse input and the camera
 	m_componentSystems.gameInputSystem->update(dt, alpha);
 
 

--- a/Sail/src/Sail/Application.cpp
+++ b/Sail/src/Sail/Application.cpp
@@ -9,6 +9,12 @@
 #include "entities/ECS.h"
 #include "entities/systems/Systems.h"
 
+
+
+// If this is defined then fixed update will run every frame which speeds up/slows down
+// the game depending on how fast the program can run
+//#define PERFORMANCE_SPEED_TEST
+
 Application* Application::s_instance = nullptr;
 std::atomic_bool Application::s_isRunning = true;
 
@@ -163,23 +169,26 @@ int Application::startGameLoop() {
 
 
 			// Run the update if enough time has passed since the last update
+#ifndef PERFORMANCE_SPEED_TEST
 			while (accumulator >= TIMESTEP) {
+#endif
 				accumulator -= TIMESTEP;
 
 				fixedUpdateStartTime = m_timer.getTimeSince<float>(startTime);
 				fixedUpdate(TIMESTEP);
 				m_fixedUpdateDelta = m_timer.getTimeSince<float>(startTime) - fixedUpdateStartTime;
+#ifndef PERFORMANCE_SPEED_TEST
 			}
-
-
 			// alpha value used for the interpolation
 			float alpha = accumulator / TIMESTEP;
+#else
+			float alpha = 1.0f; // disable interpolation
+#endif
 
 			update(m_delta, alpha);
 
 			// Render
 			render(m_delta, alpha);
-			//render(m_delta, 1.0f); // disable interpolation
 
 			// Reset just pressed keys
 			Input::GetInstance()->endFrame();

--- a/Sail/src/Sail/Application.cpp
+++ b/Sail/src/Sail/Application.cpp
@@ -100,6 +100,12 @@ int Application::startGameLoop() {
 	float elapsedTime = 0.0f;
 	UINT frameCounter = 0;
 
+
+#ifdef DEVELOPMENT
+	float fixedUpdateStartTime = 0.0f;
+	float fixedUpdateExecutionTime = 1.0f;
+#endif
+
 	// Render loop, each iteration of it results in one rendered frame
 	while (msg.message != WM_QUIT) {
 		if (PeekMessage(&msg, NULL, NULL, NULL, PM_REMOVE)) {
@@ -163,7 +169,15 @@ int Application::startGameLoop() {
 			// Run the update if enough time has passed since the last update
 			while (accumulator >= TIMESTEP) {
 				accumulator -= TIMESTEP;
+
+#ifdef DEVELOPMENT
+				fixedUpdateStartTime = m_timer.getTimeSince<float>(startTime);
+#endif
 				fixedUpdate(TIMESTEP);
+
+#ifdef DEVELOPMENT
+				fixedUpdateExecutionTime = m_timer.getTimeSince<float>(fixedUpdateStartTime);
+#endif
 			}
 
 

--- a/Sail/src/Sail/Application.cpp
+++ b/Sail/src/Sail/Application.cpp
@@ -152,15 +152,14 @@ int Application::startGameLoop() {
 			//	Logger::Warning(std::to_string(elapsedTime) + " delta over 0.0166: " + std::to_string(m_delta));
 #endif
 			// Process state specific input
-			// NOTE: player movement is processed in update() except for mouse movement which is processed here
 			processInput(m_delta);
 
 
 			// Limit the amount of updates that can happen between frames to prevent the game from completely freezing
 			// when the update is really slow for whatever reason.
 			// Allows fixed update to run twice in a row before rendering a frame so the game
-			// will slow down if (2*FPS < TICKRATE)
-			accumulator += std::min(m_delta, 2 * TIMESTEP);
+			// will slow down if (3*FPS < TICKRATE)
+			accumulator += std::min(m_delta, 3.01f * TIMESTEP);
 
 
 			// Run the update if enough time has passed since the last update

--- a/Sail/src/Sail/Application.h
+++ b/Sail/src/Sail/Application.h
@@ -88,6 +88,7 @@ public:
 	StateStorage& getStateStorage();
 	const UINT getFPS() const;
 	float getDelta() const;
+	float getFixedUpdateDelta() const;
 
 private:
 
@@ -107,6 +108,7 @@ private:
 	Timer m_timer;
 	UINT m_fps;
 	float m_delta;
+	float m_fixedUpdateDelta;
 
 	static std::atomic_bool s_isRunning;
 };

--- a/Sail/src/Sail/entities/systems/input/GameInputSystem.cpp
+++ b/Sail/src/Sail/entities/systems/input/GameInputSystem.cpp
@@ -12,6 +12,8 @@
 #include "Sail/entities/components/AudioComponent.h"
 #include "../src/Network/NWrapperSingleton.h"
 
+#include "Sail/TimeSettings.h"
+
 GameInputSystem::GameInputSystem() : BaseComponentSystem() {
 	registerComponent<LocalOwnerComponent>(true, true, false);
 	registerComponent<MovementComponent>(true, true, true);
@@ -36,8 +38,13 @@ GameInputSystem::~GameInputSystem() {
 }
 
 
+// Keyboard input is checked every tick
+void GameInputSystem::fixedUpdate() {
+	this->processKeyboardInput(TIMESTEP);
+}
+
+// Mouse input is checked every frame
 void GameInputSystem::update(float dt, float alpha) {
-	this->processKeyboardInput(dt);
 	this->processMouseInput(dt);
 	this->updateCameraPosition(alpha);
 }

--- a/Sail/src/Sail/entities/systems/input/GameInputSystem.h
+++ b/Sail/src/Sail/entities/systems/input/GameInputSystem.h
@@ -17,6 +17,8 @@ public:
 	GameInputSystem();
 	~GameInputSystem();
 
+	void fixedUpdate();
+
 	void update(float dt, float alpha);
 	void initialize(Camera* cam);
 	void clean();

--- a/Sail/src/Sail/utils/SailImGui/Profiler.cpp
+++ b/Sail/src/Sail/utils/SailImGui/Profiler.cpp
@@ -21,6 +21,7 @@ Profiler::~Profiler() {
 	delete m_vramUsageHistory;
 	delete m_cpuHistory;
 	delete m_frameTimesHistory;
+	delete m_fixedUpdateHistory;
 }
 
 void Profiler::init() {
@@ -44,6 +45,7 @@ void Profiler::init() {
 	m_vramUsageHistory = SAIL_NEW float[100];
 	m_cpuHistory = SAIL_NEW float[100];
 	m_frameTimesHistory = SAIL_NEW float[100];
+	m_fixedUpdateHistory = SAIL_NEW float[100];
 
 	for (int i = 0; i < 100; i++) {
 		m_virtRAMHistory[i] = 0.f;
@@ -51,6 +53,7 @@ void Profiler::init() {
 		m_vramUsageHistory[i] = 0.f;
 		m_cpuHistory[i] = 0.f;
 		m_frameTimesHistory[i] = 0.f;
+		m_fixedUpdateHistory[i] = 0.f;
 	}
 }
 
@@ -123,6 +126,9 @@ void Profiler::renderWindow() {
 			header = "Frame time (" + m_ftCount + " seconds)";
 			ImGui::Text(header.c_str());
 
+			header = "FixedUpdate time (" + m_fixedUpdateCount + " s, " + (1.0f/m_fixedUpdateCount) + "potential Hz)";
+			ImGui::Text(header.c_str());
+
 			header = "Virtual RAM (" + m_virtCount + " MB)";
 			ImGui::Text(header.c_str());
 
@@ -142,6 +148,10 @@ void Profiler::renderWindow() {
 				header = "\n\n\n" + m_ftCount + "(s)";
 				ImGui::PlotLines(header.c_str(), m_frameTimesHistory, 100, 0, "", 0.f, 0.015f, ImVec2(0, 100));
 			}
+			if (ImGui::CollapsingHeader("FixedUpdate Times Graph")) {
+				header = "\n\n\n" + m_fixedUpdateCount + "(s)";
+				ImGui::PlotLines(header.c_str(), m_fixedUpdateHistory, 100, 0, "", 0.f, 0.015f, ImVec2(0, 100));
+			}
 			if (ImGui::CollapsingHeader("Virtual RAM Graph")) {
 				header = "\n\n\n" + m_virtCount + "(MB)";
 				ImGui::PlotLines(header.c_str(), m_virtRAMHistory, 100, 0, "", 0.f, 500.f, ImVec2(0, 100));
@@ -160,6 +170,12 @@ void Profiler::renderWindow() {
 			ImGui::EndChild();
 
 			float dt = Application::getInstance()->getDelta();
+
+#ifdef DEVELOPMENT
+			// TODO
+			float updateTime = Application::getInstance()->getUpdateTIme();
+#endif
+
 			m_profilerTimer += dt;
 			//Updating graphs and current usage
 			if (m_profilerTimer > 0.2f) {

--- a/Sail/src/Sail/utils/SailImGui/Profiler.cpp
+++ b/Sail/src/Sail/utils/SailImGui/Profiler.cpp
@@ -126,7 +126,9 @@ void Profiler::renderWindow() {
 			header = "Frame time (" + m_ftCount + " s)";
 			ImGui::Text(header.c_str());
 
-			header = "FixedUpdate (" + m_fixedUpdateCount + " ms, " + m_potentialFixedUpdateRate + " potential Hz)";
+			// "Potential" Hz in this case means what the update rate would be if the program consisted of
+			// only the fixedUpdate() function running in a loop
+			header = "FixedUpdate (" + m_fixedUpdateCount + " ms, " + m_potentialFixedUpdateRate + " \"potential\" Hz)";
 			ImGui::Text(header.c_str());
 
 			header = "Virtual RAM (" + m_virtCount + " MB)";

--- a/Sail/src/Sail/utils/SailImGui/Profiler.h
+++ b/Sail/src/Sail/utils/SailImGui/Profiler.h
@@ -42,5 +42,6 @@ private:
 	std::string m_cpuCount;
 	std::string m_ftCount;
 	std::string m_fixedUpdateCount;
+	std::string m_potentialFixedUpdateRate;
 
 };

--- a/Sail/src/Sail/utils/SailImGui/Profiler.h
+++ b/Sail/src/Sail/utils/SailImGui/Profiler.h
@@ -35,10 +35,12 @@ private:
 	float* m_cpuHistory;
 	float* m_vramUsageHistory;
 	float* m_frameTimesHistory;
+	float* m_fixedUpdateHistory;
 	std::string m_virtCount;
 	std::string m_physCount;
 	std::string m_vramUCount;
 	std::string m_cpuCount;
 	std::string m_ftCount;
+	std::string m_fixedUpdateCount;
 
 };


### PR DESCRIPTION
Added logging of how long it takes to run `fixedUpdate()`.
`"Potential" Hz` in the Profiler output is how often `fixedUpdate()` would be able to run if that was the only thing running in the application.

Added a `PERFORMANCE_SPEED_TEST` define to `Application.cpp` which allows you to visually see how fast the game is running by coupling the fixed-update-rate to the framerate (so the higher the framerate the faster you move etc.).

Fixed a bug related to Application's update loop and the keyboard input which used to cause walking to be very slow in debug.