### PR TITLE
HF/ClientLeaveCrash

### DIFF
--- a/Sail/src/Sail/entities/systems/network/receivers/NetworkReceiverSystem.cpp
+++ b/Sail/src/Sail/entities/systems/network/receivers/NetworkReceiverSystem.cpp
@@ -195,6 +195,7 @@ void NetworkReceiverSystem::update(float dt) {
 		size_t nrOfEvents;
 		Netcode::MessageType eventType;
 		Netcode::ComponentID componentID;
+		Netcode::PlayerID playerID;
 
 
 		// -+-+-+-+-+-+-+-+ Process events -+-+-+-+-+-+-+-+ 
@@ -296,8 +297,8 @@ void NetworkReceiverSystem::update(float dt) {
 			break;
 			case Netcode::MessageType::PLAYER_DISCONNECT:
 			{
-				ar(componentID);
-				playerDisconnect(componentID);
+				ar(playerID);
+				playerDisconnect(playerID);
 			}
 			break;
 			case Netcode::MessageType::ENDGAME_STATS:


### PR DESCRIPTION
Fixed a crash caused by `PLAYER_DISCONNECTED` in receiverSystem reading a `ComponentID` when it should have been reading a `PlayerID`

Fixed #387 