### PR TITLE
Mt/network update

### DIFF
--- a/SPLASH/src/game/events/NetworkLanHostFoundEvent.h
+++ b/SPLASH/src/game/events/NetworkLanHostFoundEvent.h
@@ -1,15 +1,12 @@
 #pragma once
 #include "Sail/events/Event.h"
+#include "Network/NWrapper.h"
 
 struct NetworkLanHostFoundEvent : public Event {
-	NetworkLanHostFoundEvent(const ULONG lobbyInfo, const USHORT _hostPort, const std::string& _desc)
+	NetworkLanHostFoundEvent(const GameOnLanDescription& gameDescription)
 		: Event(Event::Type::NETWORK_LAN_HOST_FOUND)
-		, ip(lobbyInfo)
-		, hostPort(_hostPort)
-		, desc(_desc) { }
+		, gameDescription(gameDescription) { }
 	~NetworkLanHostFoundEvent() = default;
 
-	const ULONG ip = 0;
-	const USHORT hostPort;
-	const std::string desc = "";
+	const GameOnLanDescription gameDescription;
 };

--- a/SPLASH/src/game/states/EndGameState.h
+++ b/SPLASH/src/game/states/EndGameState.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Sail/states/State.h"
+struct NetworkJoinedEvent;
 
 class EndGameState final : public State {
 public:
@@ -18,6 +19,8 @@ public:
 	bool renderImgui(float dt) override;
 	// Sends events to the state
 	bool onEvent(const Event& event) override;
+
+	bool onPlayerJoined(const NetworkJoinedEvent& event);
 
 private:
 	void updatePerTickComponentSystems(float dt);

--- a/SPLASH/src/game/states/LobbyState.cpp
+++ b/SPLASH/src/game/states/LobbyState.cpp
@@ -635,10 +635,6 @@ void LobbyState::renderMenu() {
 			}
 
 			if (SailImGui::TextButton((allReady) ? "Start" : "Force start")) {
-				// Queue a removal of LobbyState, then a push of gamestate
-				NWrapperSingleton::getInstance().stopUDP();
-				//m_app->getStateStorage().setLobbyToGameData(LobbyToGameData(*m_settingBotCount, m_teamSelection));
-				
 				auto& stat = m_app->getSettings().gameSettingsStatic;
 				auto& dynamic = m_app->getSettings().gameSettingsDynamic;
 

--- a/SPLASH/src/game/states/MenuState.cpp
+++ b/SPLASH/src/game/states/MenuState.cpp
@@ -199,28 +199,21 @@ const std::string MenuState::loadPlayerName(const std::string& file) {
 
 bool MenuState::onLanHostFound(const NetworkLanHostFoundEvent& event) {
 	// Get IP (as int) then convert into char*
-	ULONG ip_as_int = event.ip;
-	Network::ip_int_to_ip_string(ip_as_int, m_ipBuffer, m_ipBufferSize);
-	std::string ip_as_string(m_ipBuffer);
-
-	// Get Port as well
-	USHORT hostPort = event.hostPort;
-	ip_as_string += ":";
-	ip_as_string.append(std::to_string(hostPort));
+	std::string serverIdentifier = event.gameDescription.ip + ":" + std::to_string(event.gameDescription.port);
 
 	// Check if it is already logged.	
 	bool alreadyExists = false;
 	for (auto& lobby : m_foundLobbies) {
-		if (lobby.ip == ip_as_string) {
+		if (lobby.serverIdentifier == serverIdentifier) {
 			alreadyExists = true;
-			lobby.description = event.desc;
+			lobby.gameDescription = event.gameDescription;
 			lobby.resetDuration();
 		}
 	}
 	// If not...
 	if (alreadyExists == false) {
 		// ...log it.
-		m_foundLobbies.push_back(FoundLobby{ ip_as_string, event.desc });
+		m_foundLobbies.push_back(FoundLobby{ event.gameDescription, serverIdentifier });
 	}
 
 	return false;
@@ -247,7 +240,7 @@ void MenuState::removeDeadLobbies() {
 		index = 0;
 
 		for (auto& lobby : m_foundLobbies) {
-			if (lobbyToRemove.ip == lobby.ip) {
+			if (lobbyToRemove.serverIdentifier == lobby.serverIdentifier) {
 				m_foundLobbies.erase(m_foundLobbies.begin()+index);
 				break;
 			}
@@ -485,10 +478,12 @@ void MenuState::renderServerBrowser() {
 #endif
 		if (ImGui::BeginChild("Lobbies", ImVec2(0, -ImGui::GetFrameHeightWithSpacing()))) {
 			// Per hosted game
-			ImGui::Columns(2, "testColumns", false);
-			ImGui::SetColumnOffset(1,ImGui::GetWindowContentRegionWidth()-100);
+			ImGui::Columns(3, "testColumns", false);
+			ImGui::SetColumnOffset(1,ImGui::GetWindowContentRegionWidth()-200);
+			ImGui::SetColumnOffset(2,ImGui::GetWindowContentRegionWidth()-100);
 			ImGui::Separator();
 			ImGui::Text("Lobby"); ImGui::NextColumn();
+			ImGui::Text("Status"); ImGui::NextColumn();
 			ImGui::Text("Players"); ImGui::NextColumn();
 			ImGui::Separator();
 
@@ -498,30 +493,33 @@ void MenuState::renderServerBrowser() {
 			}
 			for (auto& lobby : m_foundLobbies) {
 				// List as a button
-				std::string fullText = lobby.description;
-				std::string lobbyName = "";
-				std::string playerCount = "N/A";
-				// GET LOBBY NAME AND PLAYERCOUNT AS SEPARATE STRINGS
-				if (fullText == "") {
-					lobbyName = lobby.ip;
-				}
-				else {
-					int p0 = fullText.find_last_of("(");
-					int p1 = fullText.find_last_of(")");
-					lobbyName = fullText.substr(0, p0 - 1);
-					playerCount = fullText.substr(p0 + 1, p1 - p0 - 1);
+				std::string lobbyName = lobby.gameDescription.name;
+				std::string playerCount = (lobby.gameDescription.maxPlayers > 0) ? std::to_string(lobby.gameDescription.nPlayers) + " / " + std::to_string(lobby.gameDescription.maxPlayers) : "N/A";
+				std::string statusString = "Unknown";
+
+				if (lobby.gameDescription.currentState == States::Lobby) {
+					statusString = "In Lobby";
+				} else if (lobby.gameDescription.currentState == States::Game) {
+					statusString = "In Game";
+				} else if (lobby.gameDescription.currentState == States::EndGame) {
+					statusString = "Endgame";
 				}
 
+				// GET LOBBY NAME AND PLAYERCOUNT AS SEPARATE STRINGS
+				if (lobbyName == "") {
+					lobbyName = lobby.serverIdentifier;
+				}
 
 				if (ImGui::Selectable(lobbyName.c_str(), selected == index, ImGuiSelectableFlags_AllowDoubleClick | ImGuiSelectableFlags_SpanAllColumns)) {
 
 					selected = (index == selected ? -1 : index);
 					if (ImGui::IsMouseDoubleClicked(0)) {
 						// If pressed then join
-						joinLobby(lobby.ip);
+						joinLobby(lobby.serverIdentifier);
 					}
 				}
 				ImGui::NextColumn();
+				ImGui::Text(statusString.c_str()); ImGui::NextColumn();
 				ImGui::Text(playerCount.c_str()); ImGui::NextColumn();
 				index++;
 			}
@@ -537,7 +535,7 @@ void MenuState::renderServerBrowser() {
 		}
 		// If pressed then join
 		if (ImGui::Button("Join##browser") && selected > -1) {
-			joinLobby(m_foundLobbies[selected].ip);
+			joinLobby(m_foundLobbies[selected].serverIdentifier);
 		}
 		if (selected == -1) {
 			ImGui::PopStyleVar();
@@ -662,7 +660,6 @@ void MenuState::startSinglePlayer() {
 			NWrapperSingleton::getInstance().playerJoined(NWrapperSingleton::getInstance().getMyPlayer());
 		}
 		NWrapperSingleton::getInstance().stopUDP();
-		//m_app->getStateStorage().setLobbyToGameData(LobbyToGameData(0));
 
 		auto& map = m_app->getSettings().gameSettingsDynamic["map"];
 

--- a/SPLASH/src/game/states/MenuState.h
+++ b/SPLASH/src/game/states/MenuState.h
@@ -59,8 +59,8 @@ private:
 	 
 
 	struct FoundLobby {
-		std::string ip;
-		std::string description;
+		GameOnLanDescription gameDescription;
+		std::string serverIdentifier;
 		double duration = 20;
 		void resetDuration() { duration = 20; }
 	};

--- a/Sail/src/Network/NWrapper.cpp
+++ b/Sail/src/Network/NWrapper.cpp
@@ -104,20 +104,6 @@ Message NWrapper::processChatMessage(const char* data) {
 	};
 }
 
-void NWrapper::updateStateLoadStatus(States::ID state, char status) {
-	Player* myPlayer = NWrapperSingleton::getInstance().getPlayer(NWrapperSingleton::getInstance().getMyPlayerID());
-	myPlayer->lastStateStatus.state = state;
-	myPlayer->lastStateStatus.status = status;
-
-	char msg[] = { ML_UPDATE_STATE_LOAD_STATUS, NWrapperSingleton::getInstance().getMyPlayerID(), state, status, ML_NULL};
-	
-	if (NWrapperSingleton::getInstance().isHost()) {
-		sendMsgAllClients(msg, sizeof(msg));
-	} else {
-		sendMsg(msg, sizeof(msg));
-	}
-}
-
 void NWrapper::sendMsg(const char* msg, size_t size, TCP_CONNECTION_ID tcp_id) {
 	m_network->send(msg, size, tcp_id);
 }

--- a/Sail/src/Network/NWrapper.h
+++ b/Sail/src/Network/NWrapper.h
@@ -53,6 +53,14 @@ struct Player {
 	}
 };
 
+struct GameOnLanDescription {
+	std::string ip;
+	USHORT port;
+	std::string name;
+	unsigned char nPlayers;
+	unsigned char maxPlayers;
+	States::ID currentState;
+};
 
 class NWrapper : public NetworkEventHandler {
 public:
@@ -77,7 +85,7 @@ public:
 	virtual void setClientState(States::ID state, Netcode::PlayerID playerId = 255) {};
 	virtual void kickPlayer(Netcode::PlayerID playerId) {};
 	virtual void updateGameSettings(std::string s) {};
-	virtual void updateStateLoadStatus(States::ID state, char status);
+	virtual void updateStateLoadStatus(States::ID state, char status) = 0;
 
 	virtual void requestTeam(char team) {};
 	virtual void setTeamOfPlayer(char team, Netcode::PlayerID playerID, bool dispatch = true) {};
@@ -108,6 +116,7 @@ protected:
 	TCP_CONNECTION_ID parseID(std::string& data);	//
 	std::string parseName(std::string& data);		//
 	Message processChatMessage(const char* data);
+	States::ID m_lastReportedState;
 
 private:
 	friend class NWrapperSingleton;

--- a/Sail/src/Network/NWrapperClient.cpp
+++ b/Sail/src/Network/NWrapperClient.cpp
@@ -220,3 +220,15 @@ void NWrapperClient::requestTeam(char team) {
 	char msg[] = { ML_TEAM_REQUEST, team, ML_NULL };
 	sendMsg(msg, sizeof(msg));
 }
+
+void NWrapperClient::updateStateLoadStatus(States::ID state, char status) {
+	m_lastReportedState = state;
+
+	Player* myPlayer = NWrapperSingleton::getInstance().getPlayer(NWrapperSingleton::getInstance().getMyPlayerID());
+	myPlayer->lastStateStatus.state = state;
+	myPlayer->lastStateStatus.status = status;
+
+	char msg[] = { ML_UPDATE_STATE_LOAD_STATUS, NWrapperSingleton::getInstance().getMyPlayerID(), state, status, ML_NULL };
+
+	sendMsg(msg, sizeof(msg));
+}

--- a/Sail/src/Network/NWrapperClient.h
+++ b/Sail/src/Network/NWrapperClient.h
@@ -24,4 +24,6 @@ private:
 
 	virtual void requestTeam(char team);
 
+	virtual void updateStateLoadStatus(States::ID state, char status) override;
+
 };

--- a/Sail/src/Network/NWrapperHost.cpp
+++ b/Sail/src/Network/NWrapperHost.cpp
@@ -17,6 +17,12 @@
 
 bool NWrapperHost::host(int port) {
 	bool result = m_network->host(port);
+
+	m_unusedPlayerIds.clear();
+	for (Netcode::PlayerID id = 1; id < NWrapperSingleton::getInstance().getPlayerLimit(); id++) {
+		m_unusedPlayerIds.push_back(id);
+	}
+
 	return result;
 }
 
@@ -39,8 +45,15 @@ void NWrapperHost::sendChatMsg(std::string msg) {
 }
 
 void NWrapperHost::updateServerDescription() {
-	m_serverDescription = m_lobbyName + " (" + std::to_string(NWrapperSingleton::getInstance().getPlayers().size()) + "/12)";
+	m_serverDescription.clear();
+	int neededSize = 3 + m_lobbyName.length() + 1;
+	m_serverDescription.resize(neededSize);
 
+	m_serverDescription[0] = (unsigned char)NWrapperSingleton::getInstance().getPlayers().size();
+	m_serverDescription[1] = NWrapperSingleton::getInstance().getPlayerLimit();
+	m_serverDescription[2] = (unsigned char)m_lastReportedState;
+
+	memcpy(&m_serverDescription[3], &m_lobbyName[0], m_lobbyName.length() + 1);
 	m_network->setServerMetaDescription(m_serverDescription.c_str(), m_serverDescription.length() + 1);
 }
 
@@ -76,23 +89,37 @@ const std::string& NWrapperHost::getLobbyName() {
 void NWrapperHost::playerJoined(TCP_CONNECTION_ID tcp_id) {
 	// Generate an ID for the client that joined and send that information.
 
-	m_IdDistribution++;
-	unsigned char newPlayerId = m_IdDistribution;
-
-	if (NWrapperSingleton::getInstance().playerJoined(Player{ newPlayerId, "NoName" }, false)) {
-		m_connectionsMap.insert(std::pair<TCP_CONNECTION_ID, unsigned char>(tcp_id, newPlayerId));
-		//Send the newPlayerId to the new player and request a name, which upon retrieval will be sent to all clients.
-		char msg[3] = {ML_NAME_REQUEST, newPlayerId, ML_NULL};
-		m_network->send(msg, sizeof(msg), tcp_id);
+	if (m_unusedPlayerIds.empty()) {
+		m_network->kickConnection(tcp_id);
+		return;
 	} else {
-		m_IdDistribution--;
-	}
+		Netcode::PlayerID newPlayerId = m_unusedPlayerIds.front();
+		SAIL_LOG("New PLayer ID: " + std::to_string(newPlayerId));
+
+		if (NWrapperSingleton::getInstance().playerJoined(Player{ newPlayerId, "NoName" }, false)) {
+			m_unusedPlayerIds.pop_front();
+			m_connectionsMap.insert(std::pair<TCP_CONNECTION_ID, unsigned char>(tcp_id, newPlayerId));
+			//Send the newPlayerId to the new player and request a name, which upon retrieval will be sent to all clients.
+			char msg[3] = {ML_NAME_REQUEST, newPlayerId, ML_NULL};
+			m_network->send(msg, sizeof(msg), tcp_id);
+		} else {
+			m_network->kickConnection(tcp_id);
+		}
 	
-	updateServerDescription();
+		updateServerDescription();
+	}
 }
 
 void NWrapperHost::playerDisconnected(TCP_CONNECTION_ID tcp_id) {
+
+	if (m_connectionsMap.count(tcp_id) == 0) {
+		return;
+	}
+
 	Netcode::PlayerID playerID = m_connectionsMap.at(tcp_id);
+	m_connectionsMap.erase(tcp_id);
+
+	m_unusedPlayerIds.push_back(playerID);
 	PlayerLeftReason reason = m_network->wasKicked(tcp_id) ? PlayerLeftReason::KICKED : PlayerLeftReason::CONNECTION_LOST;
 	
 	char msg[] = { ML_DISCONNECT, playerID, (char)reason, ML_NULL};
@@ -295,5 +322,18 @@ void NWrapperHost::setTeamOfPlayer(char team, Netcode::PlayerID playerID, bool d
 			EventDispatcher::Instance().emit(NetworkPlayerChangedTeam(playerID));
 		}
 	}
+}
+
+void NWrapperHost::updateStateLoadStatus(States::ID state, char status) {
+	m_lastReportedState = state;
+
+	Player* myPlayer = NWrapperSingleton::getInstance().getPlayer(NWrapperSingleton::getInstance().getMyPlayerID());
+	myPlayer->lastStateStatus.state = state;
+	myPlayer->lastStateStatus.status = status;
+
+	char msg[] = { ML_UPDATE_STATE_LOAD_STATUS, NWrapperSingleton::getInstance().getMyPlayerID(), state, status, ML_NULL };
+	
+	updateServerDescription();
+	sendMsgAllClients(msg, sizeof(msg));
 }
 

--- a/Sail/src/Network/NWrapperHost.h
+++ b/Sail/src/Network/NWrapperHost.h
@@ -24,9 +24,9 @@ public:
 
 private:
 	std::map<TCP_CONNECTION_ID, Netcode::PlayerID> m_connectionsMap;
-	unsigned char m_IdDistribution = 0;
 	std::string m_lobbyName = "";
 	std::string m_serverDescription = "";
+	std::deque<Netcode::PlayerID> m_unusedPlayerIds;
 
 	void sendChatMsg(std::string msg);
 
@@ -49,5 +49,7 @@ private:
 
 	virtual void requestTeam(char team);
 	virtual void setTeamOfPlayer(char team, Netcode::PlayerID playerID, bool dispatch = true);
+
+	virtual void updateStateLoadStatus(States::ID state, char status) override;
 
 };

--- a/Sail/src/Network/NWrapperSingleton.cpp
+++ b/Sail/src/Network/NWrapperSingleton.cpp
@@ -15,7 +15,7 @@
 NWrapperSingleton::~NWrapperSingleton() {
 	if (m_isInitialized && m_wrapper != nullptr) {
 		delete m_wrapper;
-		
+
 	}
 
 	Memory::SafeDelete(m_network);
@@ -49,7 +49,7 @@ bool NWrapperSingleton::host(int port) {
 
 bool NWrapperSingleton::connectToIP(char* adress) {
 	this->initialize(false);
-	
+
 	if (!m_isHost) {
 		if (m_wrapper->connectToIP(adress) == true) {
 			return true;
@@ -57,7 +57,7 @@ bool NWrapperSingleton::connectToIP(char* adress) {
 			resetWrapper();
 		}
 	}
-	
+
 	return false;
 }
 
@@ -81,7 +81,7 @@ void NWrapperSingleton::stopUDP() {
 	m_network->stopUDP();
 }
 
-void NWrapperSingleton::startUDP(){
+void NWrapperSingleton::startUDP() {
 	m_network->startUDP();
 }
 
@@ -91,16 +91,13 @@ void NWrapperSingleton::resetPlayerList() {
 
 bool NWrapperSingleton::playerJoined(const Player& player, bool dispatchEvent) {
 	Player newPlayer(player.id, player.name.c_str());	// This will fix currupt string size.
-	
-	if (m_players.size() < m_playerLimit) {
-		m_players.push_back(newPlayer);
-		if (dispatchEvent) {
-			EventDispatcher::Instance().emit(NetworkJoinedEvent(player));
-		}
-		return true;
-	}
 
-	return false;
+	m_players.push_back(newPlayer);
+	if (dispatchEvent) {
+		EventDispatcher::Instance().emit(NetworkJoinedEvent(player));
+	}
+	return true;
+
 }
 
 bool NWrapperSingleton::playerLeft(Netcode::PlayerID& id, bool dispatchEvent, PlayerLeftReason reason) {
@@ -208,8 +205,7 @@ void NWrapperSingleton::initialize(bool asHost) {
 		if (asHost) {
 			m_isHost = true;
 			m_wrapper = SAIL_NEW NWrapperHost(m_network);
-		}
-		else {
+		} else {
 			m_isHost = false;
 			m_wrapper = SAIL_NEW NWrapperClient(m_network);
 		}
@@ -248,7 +244,7 @@ void NWrapperSingleton::handleNetworkEvents(NetworkEvent nEvent) {
 			gameDescription.currentState = States::None;
 			gameDescription.name = "";
 		}
-	
+
 		EventDispatcher::Instance().emit(NetworkLanHostFoundEvent(gameDescription));
 	}
 

--- a/Sail/src/Network/NWrapperSingleton.h
+++ b/Sail/src/Network/NWrapperSingleton.h
@@ -63,7 +63,6 @@ public:
 	void queueGameStateNetworkSenderEvent(Netcode::MessageType type, Netcode::MessageData* messageData, bool alsoSendToSelf = true);
 	unsigned char getPlayerLimit();
 	size_t averagePacketSizeSinceLastCheck();
-	Netcode::PlayerID findFreePlayerID();
 
 private:
 	// Specifically for One-Time-Events during the gamestate

--- a/Sail/src/Network/NWrapperSingleton.h
+++ b/Sail/src/Network/NWrapperSingleton.h
@@ -61,8 +61,10 @@ public:
 
 	// Messages sent to self will be dealt with in NetworkReceiverSystem
 	void queueGameStateNetworkSenderEvent(Netcode::MessageType type, Netcode::MessageData* messageData, bool alsoSendToSelf = true);
-
+	unsigned char getPlayerLimit();
 	size_t averagePacketSizeSinceLastCheck();
+	Netcode::PlayerID findFreePlayerID();
+
 private:
 	// Specifically for One-Time-Events during the gamestate
 	NetworkSenderSystem* NSS = nullptr;
@@ -74,7 +76,7 @@ private:
 	bool m_isInitialized = false;
 	bool m_isHost = false;
 
-	unsigned int m_playerLimit;
+	unsigned char m_playerLimit;
 	unsigned int m_seed;
 
 	Player m_me;

--- a/Sail/src/Network/NetworkModule.cpp
+++ b/Sail/src/Network/NetworkModule.cpp
@@ -29,8 +29,7 @@ Network::~Network() {
 	WSACleanup();
 }
 
-bool Network::initialize()
-{
+bool Network::initialize() {
 	m_shutdown = false;
 
 	if (m_initializedStatus) {
@@ -56,8 +55,7 @@ bool Network::initialize()
 	return true;
 }
 
-void Network::checkForPackages(NetworkEventHandler& handler)
-{
+void Network::checkForPackages(NetworkEventHandler& handler) {
 	//for (auto& temp : m_connections) {
 	//	std::cout << "--------------------\n";
 	//	std::cout << temp.second->id << "\n";
@@ -65,8 +63,7 @@ void Network::checkForPackages(NetworkEventHandler& handler)
 	//}
 
 	bool morePackages = true;
-	while (morePackages)
-	{
+	while (morePackages) {
 		std::lock_guard<std::mutex> lock(m_mutex_packages);
 
 #if defined(DEVELOPMENT) && defined(_LOG_TO_FILE)
@@ -84,8 +81,7 @@ void Network::checkForPackages(NetworkEventHandler& handler)
 
 void Network::checkForPackages(void (*m_callbackfunction)(NetworkEvent)) {
 	bool morePackages = true;
-	while (morePackages)
-	{
+	while (morePackages) {
 		std::lock_guard<std::mutex> lock(m_mutex_packages);
 		if (m_pstart == m_pend) {
 			morePackages = false;
@@ -96,8 +92,7 @@ void Network::checkForPackages(void (*m_callbackfunction)(NetworkEvent)) {
 	}
 }
 
-bool Network::host(unsigned short port, USHORT hostFlags)
-{
+bool Network::host(unsigned short port, USHORT hostFlags) {
 	if (m_initializedStatus != INITIALIZED_STATUS::INITIALIZED) {
 		return false;
 	}
@@ -144,15 +139,14 @@ bool Network::host(unsigned short port, USHORT hostFlags)
 	//Start a new thread that will wait for new connections
 	m_clientAcceptThread = SAIL_NEW std::thread(&Network::waitForNewConnections, this);
 	if (m_hostFlags & (USHORT)HostFlags::ENABLE_LAN_SEARCH_VISIBILITY && !startUDPSocket(m_udp_localbroadcastport)) {
-			return false;
+		return false;
 	}
 
 
 	return true;
 }
 
-bool Network::join(const char* IP_adress, unsigned short hostport)
-{
+bool Network::join(const char* IP_adress, unsigned short hostport) {
 	if (m_initializedStatus != INITIALIZED_STATUS::INITIALIZED) {
 		return false;
 	}
@@ -201,8 +195,7 @@ bool Network::join(const char* IP_adress, unsigned short hostport)
 	return true;
 }
 
-bool Network::send(const char* message, size_t size, TCP_CONNECTION_ID receiverID)
-{
+bool Network::send(const char* message, size_t size, TCP_CONNECTION_ID receiverID) {
 	m_nrOfPacketsSentSinceLast++;
 	m_sizeOfPacketsSentSinceLast += size;
 
@@ -214,8 +207,7 @@ bool Network::send(const char* message, size_t size, TCP_CONNECTION_ID receiverI
 	if (receiverID == -1 && m_initializedStatus == INITIALIZED_STATUS::IS_SERVER) {
 		int success = 0;
 		Connection* conn = nullptr;
-		for (auto it : m_connections)
-		{
+		for (auto it : m_connections) {
 			conn = it.second;
 			if (send(message, size, conn))
 				success++;
@@ -233,7 +225,7 @@ bool Network::send(const char* message, size_t size, TCP_CONNECTION_ID receiverI
 
 	size_t packetSize = MSG_SIZE_STR_LEN + size;
 	char* msg = SAIL_NEW char[packetSize]();
-	
+
 	// The message starts with a size_t stating how large the message is
 	memcpy(&msg[0], msgSizeString.c_str(), MSG_SIZE_STR_LEN);
 
@@ -270,8 +262,7 @@ bool Network::send(const char* message, size_t size, TCP_CONNECTION_ID receiverI
 	return true;
 }
 
-bool Network::send(const char* message, size_t size, Connection* conn)
-{
+bool Network::send(const char* message, size_t size, Connection* conn) {
 	if (!conn->isConnected) {
 		return false;
 	}
@@ -302,14 +293,12 @@ bool Network::send(const char* message, size_t size, Connection* conn)
 	return true;
 }
 
-void Network::setServerMetaDescription(const char* desc, int descSize)
-{
+void Network::setServerMetaDescription(const char* desc, int descSize) {
 	memset(m_serverMetaDesc, 0, HOST_META_DESC_SIZE);
 	memcpy(m_serverMetaDesc, desc, descSize);
 }
 
-bool Network::searchHostsOnLan()
-{
+bool Network::searchHostsOnLan() {
 	if (!startUDPSocket(m_udp_localbroadcastport)) {
 		return false;
 	}
@@ -327,8 +316,7 @@ bool Network::searchHostsOnLan()
 	return true;
 }
 
-bool Network::startUDPSocket(unsigned short port)
-{
+bool Network::startUDPSocket(unsigned short port) {
 	m_shutdownUDP = false;
 	ULONG bAllow = 1;
 
@@ -400,21 +388,18 @@ bool Network::startUDPSocket(unsigned short port)
 	return true;
 }
 
-void Network::listenForUDP()
-{
+void Network::listenForUDP() {
 	UDP_DATA udpdata;
 	sockaddr_in client = { 0 };
 	int clientSize = sizeof(sockaddr_in);
 
-	while (!m_shutdown && !m_shutdownUDP)
-	{
+	while (!m_shutdown && !m_shutdownUDP) {
 		memset(&udpdata, 0, sizeof(udpdata));
 		int bytesRec = recvfrom(m_udp_directMessage_socket, (char*)& udpdata, sizeof(udpdata), 0, (sockaddr*)& client, &clientSize);
 		if (bytesRec > 0) {
 			client.sin_port = htons(m_udp_localbroadcastport); //this is might needed to do direct UDP instead of broadcast
 
-			switch (udpdata.package.packagetype)
-			{
+			switch (udpdata.package.packagetype) {
 			case UDP_DATA_PACKAGE_TYPE_HOSTINFO:
 				if (m_initializedStatus) {
 #ifdef DEBUG_NETWORK
@@ -456,8 +441,7 @@ void Network::listenForUDP()
 #endif // DEBUG_NETWORK
 				break;
 			}
-		}
-		else {
+		} else {
 #ifdef DEBUG_NETWORK
 			printf("Error recvfrom with error: %d\n", WSAGetLastError());
 #endif // DEBUG_NETWORK
@@ -465,8 +449,7 @@ void Network::listenForUDP()
 	}
 }
 
-bool Network::udpSend(sockaddr* addr, char* msg, int msgSize)
-{
+bool Network::udpSend(sockaddr* addr, char* msg, int msgSize) {
 	if (::sendto(m_udp_directMessage_socket, msg, msgSize, 0, addr, sizeof(sockaddr_in)) == SOCKET_ERROR) {
 #ifdef DEBUG_NETWORK
 		printf("Error sendto udp with error: %d\n", WSAGetLastError());
@@ -477,8 +460,7 @@ bool Network::udpSend(sockaddr* addr, char* msg, int msgSize)
 	return true;
 }
 
-TCP_CONNECTION_ID Network::generateID()
-{
+TCP_CONNECTION_ID Network::generateID() {
 	TCP_CONNECTION_ID id = 0;
 	std::random_device rd;   // non-deterministic generator.
 	std::mt19937 gen(rd());
@@ -486,13 +468,11 @@ TCP_CONNECTION_ID Network::generateID()
 	if (m_hostFlags & (USHORT)HostFlags::USE_RANDOM_IDS) {
 		int n = sizeof(TCP_CONNECTION_ID) / sizeof(int);
 
-		for (size_t i = 0; i < n; i++)
-		{
+		for (size_t i = 0; i < n; i++) {
 			unsigned int r = gen();
 			id |= (TCP_CONNECTION_ID)r << (i * 32);
 		}
-	}
-	else {
+	} else {
 		id = m_nextID++;
 	}
 
@@ -507,8 +487,7 @@ Network::INITIALIZED_STATUS Network::getInitializeStatus() {
 	return m_initializedStatus;
 }
 
-void Network::shutdown()
-{
+void Network::shutdown() {
 	if (!m_initializedStatus) {
 		return;
 	}
@@ -522,8 +501,7 @@ void Network::shutdown()
 #ifdef DEBUG_NETWORK
 			printf("Error closing m_soc\n");
 #endif
-		}
-		else if (m_clientAcceptThread) {
+		} else if (m_clientAcceptThread) {
 			m_clientAcceptThread->join();
 			delete m_clientAcceptThread;
 		}
@@ -531,16 +509,14 @@ void Network::shutdown()
 
 	{
 		std::lock_guard<std::mutex> lock(m_mutex_connections);
-		for (auto it : m_connections)
-		{
+		for (auto it : m_connections) {
 			Connection* conn = it.second;
 			::shutdown(conn->socket, 2);
 			if (closesocket(conn->socket) == SOCKET_ERROR) {
 #ifdef DEBUG_NETWORK
 				printf((std::string("Error closing socket") + std::to_string(conn->id) + "\n").c_str());
 #endif
-			}
-			else if (conn->thread) {
+			} else if (conn->thread) {
 				conn->thread->join();
 				delete conn->thread;
 				delete conn;
@@ -554,13 +530,11 @@ void Network::shutdown()
 	m_initializedStatus = INITIALIZED_STATUS::INITIALIZED;
 }
 
-void Network::ip_int_to_ip_string(ULONG ip, char* buffer, int buffersize)
-{
+void Network::ip_int_to_ip_string(ULONG ip, char* buffer, int buffersize) {
 	inet_ntop(AF_INET, &ip, buffer, buffersize);
 }
 
-ULONG Network::ip_string_to_ip_int(char* ip)
-{
+ULONG Network::ip_string_to_ip_int(char* ip) {
 	int result = 0;
 	inet_pton(AF_INET, ip, &result);
 	return result;
@@ -592,7 +566,7 @@ void Network::startUDP() {
 void Network::kickConnection(TCP_CONNECTION_ID tcp_id) {
 	if (m_connections.find(tcp_id) != m_connections.end()) {
 		//TODO: Send Kicked Message to be nice.
-		
+
 		Connection* conn = m_connections[tcp_id];
 		conn->wasKicked = true;
 		::shutdown(conn->socket, 2);
@@ -631,12 +605,11 @@ void Network::addNetworkEvent(NetworkEvent n, int dataSize, const char* data) {
 	}
 
 	// Copy the incoming data to a message
-	
+
 	if (n.eventType == NETWORK_EVENT_TYPE::HOST_ON_LAN_FOUND) {
 		// UDP MESSAGE
 		memcpy(&m_awaitingMessages[m_pend].HostFoundOnLanData, &n.data->HostFoundOnLanData, sizeof(n.data->HostFoundOnLanData));
-	}
-	else {
+	} else {
 		// All other messages
 		m_awaitingMessages[m_pend].Message.rawMsg = SAIL_NEW char[dataSize]();
 		memcpy(m_awaitingMessages[m_pend].Message.rawMsg, data, dataSize);
@@ -655,10 +628,8 @@ void Network::addNetworkEvent(NetworkEvent n, int dataSize, const char* data) {
 	}
 }
 
-void Network::waitForNewConnections()
-{
-	while (!m_shutdown)
-	{
+void Network::waitForNewConnections() {
+	while (!m_shutdown) {
 		sockaddr_in client;
 		int clientSize = sizeof(client);
 
@@ -693,8 +664,7 @@ void Network::waitForNewConnections()
 	}
 }
 
-void Network::listen(Connection* conn)
-{
+void Network::listen(Connection* conn) {
 	NetworkEvent nEvent;
 	nEvent.from_tcp_id = conn->tcp_id;
 	nEvent.eventType = NETWORK_EVENT_TYPE::CONNECTION_ESTABLISHED;
@@ -724,8 +694,7 @@ void Network::listen(Connection* conn)
 #ifdef DEBUG_NETWORK
 		printf((std::string("bytesReceived: ") + std::to_string(bytesReceived) + "\n").c_str());
 #endif // DEBUG_NETWORK		
-		switch (bytesReceived)
-		{
+		switch (bytesReceived) {
 		case 0:
 #ifdef DEBUG_NETWORK
 			printf("Client Disconnected\n");


### PR DESCRIPTION
Made currently running game sessions visible again in the lobby list.
Lobby list now displays game session status like "in Lobby", "in Game" or "Endgame".
PlayerID is now always contained within the interval [0, player_limit[ ( [0-12[ )
Players joining when endgame state is running will be placed in the lobby.