### PR TITLE
Updated hasComponent() and getComponent()

### DIFF
--- a/Sail/src/Sail/entities/Entity.cpp
+++ b/Sail/src/Sail/entities/Entity.cpp
@@ -72,10 +72,13 @@ void Entity::removeComponent(ComponentTypeID id) {
 	const ComponentTypeBitID bid = GetBIDofID(id);
 
 	if ((m_componentTypes & bid).any()) {
-		m_components[id].reset();
+		m_components[id].reset(nullptr);
 
 		// Set the component type bit to 0 if it was 1
-		m_componentTypes ^= bid;
+		std::bitset<MAX_NUM_COMPONENTS_TYPES> bits = 1;
+		bits <<= id;									// set a 1 to the type bit
+		bits = ~bits;									// set a 0 to the type bit and rest to 1
+		m_componentTypes = m_componentTypes & bits;		// keep the values of each not except the type bit which is now 0
 
 		// Remove this entity from systems which required the removed component
 		removeFromSystems();

--- a/Sail/src/Sail/entities/Entity.h
+++ b/Sail/src/Sail/entities/Entity.h
@@ -108,8 +108,8 @@ inline ComponentType* Entity::addComponent(Targs... args) {
 template<typename ComponentType>
 inline void Entity::removeComponent() {
 	if ( hasComponent<ComponentType>() ) {
-		m_components[ComponentType::ID].reset();
-		
+		m_components[ComponentType::ID].reset(nullptr);
+
 		// Set the component type bit to 0 if it was 1
 		std::bitset<MAX_NUM_COMPONENTS_TYPES> bits = 0;
 		bits |= ComponentType::getBID();				// set a 1 to the type bit
@@ -123,10 +123,15 @@ inline void Entity::removeComponent() {
 
 template<typename ComponentType>
 inline ComponentType* Entity::getComponent() {
-	return static_cast<ComponentType*>(m_components[ComponentType::ID].get());
+	if (hasComponent<ComponentType>()) {
+		return static_cast<ComponentType*>(m_components[ComponentType::ID].get());
+	}
+	return nullptr;
 }
 
 template<typename ComponentType>
 inline bool Entity::hasComponent() const {
-	return ( m_componentTypes & ComponentType::getBID() ).any();
+	bool bitTrue = (m_componentTypes & ComponentType::getBID()).any();
+	bool ptrTrue = m_components[ComponentType::ID] != nullptr;
+	return bitTrue && ptrTrue;
 }


### PR DESCRIPTION
Modified how Entity::hasComponent() and Entity::getComponent() works.
Components are reset with nullptr ("should" not make a difference)